### PR TITLE
Use indexmap for returning dicts to Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "indexmap",
  "object_store",
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ bytes = "1.7.0"
 chrono = "0.4.38"
 futures = "0.3.31"
 http = "1.1"
+indexmap = "2"
 object_store = "0.11"
-pyo3 = { version = "0.22", features = ["macros"] }
+pyo3 = { version = "0.22", features = ["macros", "indexmap"] }
 pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", features = [
     "tokio-runtime",
 ] }

--- a/object-store-rs/Cargo.toml
+++ b/object-store-rs/Cargo.toml
@@ -22,6 +22,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+indexmap = { workspace = true }
 object_store = { workspace = true }
 pyo3 = { workspace = true, features = ["chrono", "abi3-py39"] }
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }

--- a/object-store-rs/src/list.rs
+++ b/object-store-rs/src/list.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::stream::BoxStream;
 use futures::StreamExt;
+use indexmap::IndexMap;
 use object_store::path::Path;
 use object_store::{ListResult, ObjectMeta, ObjectStore};
 use pyo3::prelude::*;
@@ -21,7 +21,7 @@ impl PyObjectMeta {
 
 impl IntoPy<PyObject> for PyObjectMeta {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        let mut dict = HashMap::with_capacity(5);
+        let mut dict = IndexMap::with_capacity(5);
         dict.insert("location", self.0.location.as_ref().into_py(py));
         dict.insert("last_modified", self.0.last_modified.into_py(py));
         dict.insert("size", self.0.size.into_py(py));
@@ -35,7 +35,7 @@ pub(crate) struct PyListResult(ListResult);
 
 impl IntoPy<PyObject> for PyListResult {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        let mut dict = HashMap::with_capacity(2);
+        let mut dict = IndexMap::with_capacity(2);
         dict.insert(
             "common_prefixes",
             self.0

--- a/object-store-rs/src/put.rs
+++ b/object-store-rs/src/put.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use indexmap::IndexMap;
 use object_store::path::Path;
 use object_store::{ObjectStore, PutPayload, PutResult, WriteMultipart};
 use pyo3::prelude::*;
@@ -80,7 +80,7 @@ pub(crate) struct PyPutResult(PutResult);
 
 impl IntoPy<PyObject> for PyPutResult {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        let mut dict = HashMap::with_capacity(2);
+        let mut dict = IndexMap::with_capacity(2);
         dict.insert("e_tag", self.0.e_tag.into_py(py));
         dict.insert("version", self.0.version.into_py(py));
         dict.into_py(py)


### PR DESCRIPTION
Ensures that the returned Python `dict` will always be ordered the same way.